### PR TITLE
fix: missing runtime dependency tslib

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "klaw-sync": "^6.0.0",
     "lunr": "^2.3.9",
     "lunr-languages": "^1.4.0",
-    "mark.js": "^8.11.1"
+    "mark.js": "^8.11.1",
+    "tslib": "^2.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7256,7 +7256,7 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.1.0:
+tslib@^2.1.0, tslib@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
   integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==


### PR DESCRIPTION
Using `importHelpers` in `tsconfig.json` means there's a runtime
dependency on tslib.