### PR TITLE
fix: parse `h1` from the whole `article`

### DIFF
--- a/src/server/utils/parseDocument.ts
+++ b/src/server/utils/parseDocument.ts
@@ -4,7 +4,7 @@ import { getCondensedText } from "./getCondensedText";
 const HEADINGS = "h1, h2, h3";
 
 export function parseDocument($: cheerio.Root): ParsedDocument {
-  const $pageTitle = $("article header h1").first();
+  const $pageTitle = $("article h1").first();
   const pageTitle = $pageTitle.text();
 
   const sections: ParsedDocumentSection[] = [];


### PR DESCRIPTION
When using singular `#` for setting a title of a Docusaurus document, it was not queried by the `docusaurus-search-local` since Docusaurus doesn't wrap `h1` in `header` in such cases.

Check out the following example:

`/docs/code.md`
```
# Code

## Stick to the software engineering fundamentals

...

## Avoid [code smells](https://en.wikipedia.org/wiki/Code_smell)

...

```

This way, page title property is empty for `##` headings