### PR TITLE
Fix indexing when trailingSlash is explicitly set

### DIFF
--- a/docusaurus-search-local/src/server/utils/processDocInfos.ts
+++ b/docusaurus-search-local/src/server/utils/processDocInfos.ts
@@ -116,8 +116,23 @@ export function processDocInfos(
             isSameOrSubRoute(route, basePath)
           )
         ) {
-          if (docs.size === 0 || docs.has(url)) {
-            return { route, url, type: "docs" };
+          if (docs.size === 0) {
+            return {route, url, type: 'docs'};
+          }
+          if (siteConfig.trailingSlash === true) {
+            // All routePaths have a trailing slash
+            // index.(md|*) permalink has trailing slash, other permalinks don't
+            if (docs.has(url) || docs.has(removeTrailingSlash(url))) {
+              return {route, url, type: 'docs'};
+            }
+          } else if (siteConfig.trailingSlash === false) {
+            // All routePaths don't have a trailing slash
+            // index.(md|*) permalink has trailing slash, other permalinks don't
+            if (docs.has(addTrailingSlash(url)) || docs.has(url)) {
+              return {route, url, type: 'docs'};
+            }
+          } else if (docs.has(url)) {
+            return {route, url, type: 'docs'};
           }
           return;
         }
@@ -159,4 +174,7 @@ function isSameOrSubRoute(childRoute: string, parentRoute: string): boolean {
 // The input route must not end with a slash.
 function addTrailingSlash(route: string): string {
   return `${route}/`;
+}
+function removeTrailingSlash(route: string): string {
+  return route.replace(/\/$/, '');
 }


### PR DESCRIPTION

Problem:

When this plugin gathers files to be indexed it does some checks to ensure the correct files are included in the correct version. It relies on the buildData passed by docusaurus, namely a route list: `routePaths`; these values are affected by the `trailingSlash` docusaurus config (https://docusaurus.io/docs/api/docusaurus-config#trailingSlash).

Assuming the following folder structure:
/docs
--/folder
----index.mdx
----fileA.mdx
----fileB.mdx

Here's what currently happens when `trailingSlash` is set to `false` explicitly: Only index.mdx is processed.

Here's what currently happens when `trailingSlash` is set to `true` explicitly: Only fileA.mdx and fileB.mdx are processed.

When `trailingSlash` is not set/undefined, all files are processed correctly.

A bit more details from the proposed fix implementation:

When `trailingSlash: false`

- `routePaths`: All routes have no trailing slashes
- `docs`: Trailing Slash for 'index' like files, no slash for regular files

Check `docs.has(url)` fails for index.html, works for other files

When `trailingSlash: true`

- `routePaths`: All routes have trailing slashes
- `docs`: Trailing Slash for 'index' like files, no slash for regular files (Same as above)

Check `docs.has(url)` works for index.html, fails for other files

This problem is also partially highlighted here in this issue https://github.com/easyops-cn/docusaurus-search-local/issues/258

