### PR TITLE
fix: add decodeURI in useSearchQuery

### DIFF
--- a/docusaurus-search-local/src/client/theme/hooks/useSearchQuery.ts
+++ b/docusaurus-search-local/src/client/theme/hooks/useSearchQuery.ts
@@ -21,7 +21,7 @@ function useSearchQuery(): any {
   } = useDocusaurusContext();
 
   const params = ExecutionEnvironment.canUseDOM ? new URLSearchParams(location.search) : null;
-  const searchValue = params?.get(SEARCH_PARAM_QUERY) || "";
+  const searchValue = decodeURI(params?.get(SEARCH_PARAM_QUERY) || "");
   const searchContext = params?.get(SEARCH_PARAM_CONTEXT) || "";
   const searchVersion = params?.get(SEARCH_PARAM_VERSION) || "";
 


### PR DESCRIPTION
When searching something not latin users see `Search results for "%D1%81%D0%BB%D0%BE%D0%B2%D0%BE"` instead of `encodeURI('слово')`