### PR TITLE
fix: Cosmetic fix for search page on small screens

### DIFF
--- a/docusaurus-search-local/src/client/theme/SearchPage/SearchPage.module.css
+++ b/docusaurus-search-local/src/client/theme/SearchPage/SearchPage.module.css
@@ -1,4 +1,4 @@
-.searchVersionInput,
+.searchContextInput,
 .searchQueryInput {
   border-radius: var(--ifm-global-radius);
   border: var(--ifm-global-border-width) solid
@@ -29,4 +29,25 @@
 .searchResultItemSummary {
   font-style: italic;
   margin: 0.5rem 0px 0px;
+}
+
+@media only screen and (max-width: 996px) {
+  .searchQueryColumn {
+    max-width: 60% !important;
+  }
+
+  .searchContextColumn {
+    max-width: 40% !important;
+  }
+}
+
+@media screen and (max-width: 576px) {
+  .searchQueryColumn {
+    max-width: 100% !important;
+  }
+
+  .searchContextColumn {
+    max-width: 100% !important;
+    padding-left: var(--ifm-spacing-horizontal) !important;
+  }
 }

--- a/docusaurus-search-local/src/client/theme/SearchPage/SearchPage.tsx
+++ b/docusaurus-search-local/src/client/theme/SearchPage/SearchPage.tsx
@@ -133,7 +133,8 @@ function SearchPageContent(): React.ReactElement {
 
         <div className="row">
           <div
-            className={clsx("col", styles.searchQueryColumn, {
+            className={clsx("col", {
+              [styles.searchQueryColumn]: Array.isArray(searchContextByPaths),
               "col--9": Array.isArray(searchContextByPaths),
               "col--12": !Array.isArray(searchContextByPaths),
             })}
@@ -155,12 +156,12 @@ function SearchPageContent(): React.ReactElement {
                 "col",
                 "col--3",
                 "padding-left--none",
-                styles.searchVersionColumn
+                styles.searchContextColumn
               )}
             >
               <select
                 name="search-context"
-                className={styles.searchVersionInput}
+                className={styles.searchContextInput}
                 id="context-selector"
                 value={searchContext}
                 onChange={(e) => updateSearchContext(e.target.value)}


### PR DESCRIPTION
This is a styling fix for UI elements introduced by #319. The fix is only relevant for small screens.

Styles are pretty much copies from [here](https://github.com/facebook/docusaurus/blob/1b9e2f2d451f7933df409da67f1f1bb54350a78c/packages/docusaurus-theme-search-algolia/src/theme/SearchPage/styles.module.css) with a few changes: 

### Before this PR:

<img width="200" alt="Screenshot 2023-02-17 at 10 44 35" src="https://user-images.githubusercontent.com/692542/219612282-23c727ba-4666-4025-ad04-b7e1e2349c34.png">

### After this PR:
**Without context search**
<img width="700" alt="Screenshot 2023-02-17 at 10 40 57" src="https://user-images.githubusercontent.com/692542/219612381-c9ece9b4-4273-4cfb-ab55-62f040adde14.png">
<img width="200" alt="Screenshot 2023-02-17 at 10 41 07" src="https://user-images.githubusercontent.com/692542/219612385-4fa95035-3503-4e7d-837a-b640fdd5232a.png">

**With context search**
<img width="200" alt="Screenshot 2023-02-17 at 10 42 40" src="https://user-images.githubusercontent.com/692542/219612390-cf463961-8ba1-43ac-890c-5b8b89299fe4.png">
<img width="700" alt="Screenshot 2023-02-17 at 10 42 45" src="https://user-images.githubusercontent.com/692542/219612394-cd592bfe-5577-440d-9c53-d561e8f04db4.png">
