### PR TITLE
Fixed search link when update to Docusaurus 3.4.0, fix both search page and search bar

### DIFF
--- a/docusaurus-search-local/src/client/theme/SearchBar/SearchBar.tsx
+++ b/docusaurus-search-local/src/client/theme/SearchBar/SearchBar.tsx
@@ -295,6 +295,10 @@ export default function SearchBar({
             url += `?${params.toString()}`;
           }
           if (h) {
+            const taglink = String(h);
+            if (taglink.includes("#")){
+              h = taglink.slice(taglink.lastIndexOf("#") , taglink.length);
+            }
             url += h;
           }
           history.push(url);

--- a/docusaurus-search-local/src/client/theme/SearchPage/SearchPage.tsx
+++ b/docusaurus-search-local/src/client/theme/SearchPage/SearchPage.tsx
@@ -274,6 +274,10 @@ function SearchResultItem({
     }
     search = `?${params.toString()}`;
   }
+  const taglink = String(document.h);
+  if (taglink.includes("#")){
+    document.h = taglink.slice(taglink.lastIndexOf("#") , taglink.length);
+  }
   return (
     <article className={styles.searchResultItem}>
       <h2>


### PR DESCRIPTION
Fixed search link when update to Docusaurus 3.4.0, fix both search page and search bar with footer link to search page - AnonID.TOP