### PR TITLE
support add document to multiple indexes

### DIFF
--- a/docusaurus-search-local/src/server/utils/postBuildFactory.ts
+++ b/docusaurus-search-local/src/server/utils/postBuildFactory.ts
@@ -48,15 +48,14 @@ export function postBuildFactory(
           for (const doc of documents) {
             if (doc.u.startsWith(baseUrl)) {
               const uri = doc.u.substring(baseUrl.length);
-              let matchedPath: string | undefined;
+              let matchedPathes: string[] = [];
               for (const _path of searchContextByPaths) {
                 const path = typeof _path === "string" ? _path : _path.path;
                 if (uri === path || uri.startsWith(`${path}/`)) {
-                  matchedPath = path;
-                  break;
+                  matchedPathes.push(path);
                 }
               }
-              if (matchedPath) {
+              for (const matchedPath of matchedPathes) {
                 let dirAllDocs = docsByDirMap.get(matchedPath);
                 if (!dirAllDocs) {
                   dirAllDocs = [];
@@ -67,9 +66,9 @@ export function postBuildFactory(
                   dirAllDocs[docIndex] = dirDocs = [];
                 }
                 dirDocs.push(doc);
-                if (!useAllContextsWithNoSearchContext) {
-                  continue;
-                }
+              }
+              if (matchedPathes.length > 0 && !useAllContextsWithNoSearchContext) {
+                continue;
               }
             }
             rootAllDocs[docIndex].push(doc);


### PR DESCRIPTION
Sometimes we may want a folder within a doc to have dedicated index, such as an FAQ folder, so that users can search FAQs only and find docs more accurately. Meanwhile, the FAQ should also be added to the doc index, so users can still find FAQs when reading other docs.

[issue 407](https://github.com/easyops-cn/docusaurus-search-local/issues/407)