### PR TITLE
fix: append a `/` to the search link

### DIFF
--- a/docusaurus-search-local/src/client/theme/SearchBar/SearchBar.tsx
+++ b/docusaurus-search-local/src/client/theme/SearchBar/SearchBar.tsx
@@ -220,7 +220,7 @@ export default function SearchBar({
         }
         params.set("version", versionUrl.substring(baseUrl.length));
       }
-      const url = `${baseUrl}search?${params.toString()}`;
+      const url = `${baseUrl}search/?${params.toString()}`;
       a.href = url;
       a.textContent = linkText;
       a.addEventListener("click", (e) => {


### PR DESCRIPTION
Thanks for this plugin!

Most hosting providers HTTP redirect `mysite.com/docs/search?q=test` to `mysite.com/docs/search/?q=test`... except S3 which tosses out the query string and redirects to `mysite.com/docs/search/`.

Rather than relying on the backend redirect to work, tweak the link here on the frontend to already contain the slash suffixed path.