### PR TITLE
Add option that removes the See All Results link in the search results

### DIFF
--- a/docusaurus-search-local/src/client/theme/SearchBar/SearchBar.tsx
+++ b/docusaurus-search-local/src/client/theme/SearchBar/SearchBar.tsx
@@ -30,6 +30,7 @@ import {
   searchContextByPaths,
   hideSearchBarWithNoSearchContext,
   useAllContextsWithNoSearchContext,
+  removeSeeAllResults,
 } from "../../utils/proxiedGenerated";
 import LoadingRing from "../LoadingRing/LoadingRing";
 import { normalizeContextByPath } from "../../utils/normalizeContextByPath";
@@ -280,7 +281,9 @@ export default function SearchBar({
               const a = searchFooterLinkElement({ query, isEmpty });
               const div = document.createElement("div");
               div.className = styles.hitFooter;
-              div.appendChild(a);
+              if(removeSeeAllResults === false){
+                div.appendChild(a);
+              }
               return div;
             },
           },

--- a/docusaurus-search-local/src/declarations.ts
+++ b/docusaurus-search-local/src/declarations.ts
@@ -13,6 +13,7 @@ declare module "*/generated.js" {
   export const explicitSearchResultPath: boolean;
   export const searchBarShortcut: boolean;
   export const searchBarShortcutHint: boolean;
+  export const removeSeeAllResults: boolean;
   export const searchBarPosition: "left" | "right";
   export const docsPluginIdForPreferredVersion: string;
   export const indexDocs: boolean;

--- a/docusaurus-search-local/src/index.ts
+++ b/docusaurus-search-local/src/index.ts
@@ -199,4 +199,11 @@ export interface PluginOptions {
    * @default false
    */
   forceIgnoreNoIndex?: boolean;
+
+  /**
+   * Whether to remove the see all results button.
+   * 
+   * @default false
+   */
+  removeSeeAllResults?: boolean;
 }

--- a/docusaurus-search-local/src/server/utils/generate.ts
+++ b/docusaurus-search-local/src/server/utils/generate.ts
@@ -20,6 +20,7 @@ export function generate(config: ProcessedPluginOptions, dir: string): string {
     searchContextByPaths,
     hideSearchBarWithNoSearchContext,
     useAllContextsWithNoSearchContext,
+    removeSeeAllResults,
   } = config;
   const indexHash = getIndexHash(config);
   const contents: string[] = [];
@@ -28,6 +29,13 @@ export function generate(config: ProcessedPluginOptions, dir: string): string {
       removeDefaultStemmer
     )};`
   );
+
+  contents.push(
+    `export const removeSeeAllResults = ${JSON.stringify(
+      removeSeeAllResults
+    )};`
+  );
+  
   if (highlightSearchTermsOnTargetPage) {
     contents.push(
       `export { default as Mark } from ${JSON.stringify(

--- a/docusaurus-search-local/src/server/utils/validateOptions.ts
+++ b/docusaurus-search-local/src/server/utils/validateOptions.ts
@@ -32,6 +32,7 @@ const schema = Joi.object<PluginOptions>({
   removeDefaultStopWordFilter: Joi.boolean().default(false),
   removeDefaultStemmer: Joi.boolean().default(false),
   highlightSearchTermsOnTargetPage: Joi.boolean().default(false),
+  removeSeeAllResults:Joi.boolean().default(false),
   searchResultLimits: Joi.number().default(8),
   searchResultContextMaxLength: Joi.number().default(50),
   explicitSearchResultPath: Joi.boolean().default(false),


### PR DESCRIPTION
## Description

This PR adds an option, defaulted to false, to remove the `See All Results` link in the search results. This is meant as a workaround for the accessibility bug which prevents keyboard navigation to this link.

![image](https://github.com/user-attachments/assets/3bbbc932-87bd-4247-9628-b6019e99917d)


Related: https://github.com/easyops-cn/docusaurus-search-local/issues/490

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a configurable option to remove the "See All Results" button in search results
	- Users can now control the visibility of the search results footer link via a new `removeSeeAllResults` boolean setting

- **Configuration**
	- New `removeSeeAllResults` option defaults to `false`
	- Allows fine-tuning of search result display behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->