### PR TITLE
feat: make open-ask-ai async and optional

### DIFF
--- a/docusaurus-search-local/package.json
+++ b/docusaurus-search-local/package.json
@@ -46,8 +46,10 @@
     "lunr": "^2.3.9",
     "lunr-languages": "^1.4.0",
     "mark.js": "^8.11.1",
-    "open-ask-ai": "^0.7.3",
     "tslib": "^2.4.0"
+  },
+  "optionalDependencies": {
+    "open-ask-ai": "^0.7.3"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.0.0",

--- a/docusaurus-search-local/src/declarations.ts
+++ b/docusaurus-search-local/src/declarations.ts
@@ -7,6 +7,22 @@ declare module "@easyops-cn/autocomplete.js" {
   export const noConflict: () => void;
 }
 
+// Type definition for open-ask-ai (optional dependency)
+declare module "open-ask-ai" {
+  export interface AskAIWidgetProps {
+    [key: string]: any;
+  }
+  export interface AskAIWidgetRef {
+    openWithNewSession: (query: string) => void;
+  }
+  export const AskAIWidget: any;
+}
+
+// Local interface for askAi config
+interface AskAIConfig {
+  [key: string]: any;
+}
+
 declare module "*/generated.js" {
   export const removeDefaultStemmer: string[];
   export class Mark {
@@ -29,7 +45,7 @@ declare module "*/generated.js" {
   export const hideSearchBarWithNoSearchContext: boolean;
   export const useAllContextsWithNoSearchContext: boolean;
   export const forceIgnoreNoIndex: boolean;
-  export const askAi: import("open-ask-ai").AskAIWidgetProps;
+  export const askAi: AskAIConfig | undefined;
 }
 
 declare module "*/generated-constants.js" {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2912,6 +2912,9 @@ __metadata:
     "@docusaurus/theme-common": ^2 || ^3
     react: ^16.14.0 || ^17 || ^18 || ^19
     react-dom: ^16.14.0 || 17 || ^18 || ^19
+  dependenciesMeta:
+    open-ask-ai:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Fixes #558

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * OpenAskAI widget is now optional and will only load if available, ensuring stable operation regardless of whether the module is installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->