### PR TITLE
fix: some languages need lunr wordcut

### DIFF
--- a/docusaurus-search-local/src/server/utils/buildIndex.ts
+++ b/docusaurus-search-local/src/server/utils/buildIndex.ts
@@ -6,6 +6,7 @@ import {
   SearchDocument,
   WrappedIndex,
 } from "../../shared/interfaces";
+import { LANGUAGES_NEED_WORDCUT } from "../../shared/constants";
 
 let pluginInitialized = false;
 let plugin: lunr.Builder.Plugin | undefined;
@@ -27,6 +28,9 @@ export function buildIndex(
     }
     if (language.includes("ja") || language.includes("jp")) {
       require("lunr-languages/tinyseg")(lunr);
+    }
+    if (LANGUAGES_NEED_WORDCUT.some((item) => language.includes(item))) {
+      (lunr as any).wordcut = require("lunr-languages/wordcut");
     }
     for (const lang of language.filter(
       (item) => item !== "en" && item !== "zh"

--- a/docusaurus-search-local/src/server/utils/generate.ts
+++ b/docusaurus-search-local/src/server/utils/generate.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import path from "path";
 import { ProcessedPluginOptions } from "../../shared/interfaces";
 import { getIndexHash } from "./getIndexHash";
+import { LANGUAGES_NEED_WORDCUT } from "../../shared/constants";
 
 export function generate(config: ProcessedPluginOptions, dir: string): string {
   const {
@@ -120,6 +121,13 @@ export function generate(config: ProcessedPluginOptions, dir: string): string {
       `require(${JSON.stringify(
         require.resolve("lunr-languages/tinyseg")
       )})(lunr);`
+    );
+  }
+  if (language.some((item) => LANGUAGES_NEED_WORDCUT.includes(item))) {
+    constantContents.push(
+      `lunr.wordcut = require(${JSON.stringify(
+        require.resolve("lunr-languages/wordcut")
+      )});`
     );
   }
   for (const lang of language.filter(

--- a/docusaurus-search-local/src/shared/constants.ts
+++ b/docusaurus-search-local/src/shared/constants.ts
@@ -1,0 +1,1 @@
+export const LANGUAGES_NEED_WORDCUT = ["th", "hi", "te", "ta", "kn", "sa"];


### PR DESCRIPTION
Fixes #438

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * Improved search functionality with enhanced word segmentation support for Thai, Hindi, Telugu, Tamil, Kannada, and Sanskrit languages. Proper word cutting is now enabled for these languages, delivering more accurate and relevant search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->