### PR TITLE
fix: add package bugs metadata

### DIFF
--- a/docusaurus-search-local/package.json
+++ b/docusaurus-search-local/package.json
@@ -8,6 +8,9 @@
     "directory": "packages/docusaurus-search-local"
   },
   "homepage": "https://github.com/easyops-cn/docusaurus-search-local",
+  "bugs": {
+    "url": "https://github.com/easyops-cn/docusaurus-search-local/issues"
+  },
   "scripts": {
     "start": "concurrently -k -n client,server,types \"yarn run start:client\" \"yarn run start:server\" \"yarn run start:types\"",
     "start:client": "tsc --watch --project tsconfig.client.json",


### PR DESCRIPTION
## Summary
- add the missing `bugs.url` metadata for `@easyops-cn/docusaurus-search-local`
- keep the existing repository and homepage metadata unchanged

## Verification
- `node -e "const p=require('./docusaurus-search-local/package.json'); if(!p.bugs?.url) process.exit(1); console.log(JSON.stringify({name:p.name,homepage:p.homepage,bugs:p.bugs,repository:p.repository},null,2))"`
- `git diff --check`

Bounty: https://github.com/charles-openclaw/charles-microbounties/issues/746


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata to include bug reporting information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->